### PR TITLE
Improve root parse speed.

### DIFF
--- a/TACTBench/EncodingBenchmark.cs
+++ b/TACTBench/EncodingBenchmark.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using TACTSharp;
+
+namespace TACTBench
+{
+    [MemoryDiagnoser]
+    public class EncodingBenchmark
+    {
+        private BuildInstance? _build;
+
+        [GlobalSetup]
+        public async Task SpecificSetup()
+        {
+            var versions = await CDN.GetProductVersions("wow");
+            foreach (var line in versions.Split('\n'))
+            {
+                if (!line.StartsWith("us|"))
+                    continue;
+
+                var splitLine = line.Split('|');
+
+                Settings.BuildConfig ??= splitLine[1];
+                Settings.CDNConfig ??= splitLine[2];
+                break;
+            }
+
+            _build = new BuildInstance(Settings.BuildConfig!, Settings.CDNConfig!);
+            await _build.Load();
+        }
+
+        [Benchmark]
+        public RootInstance.Record TestRootLookup()
+        {
+            ref readonly var fileEntry = ref _build!.Root!.FindFileDataID(1349477);
+            Debug.Assert(!Unsafe.IsNullRef(in fileEntry));
+            return fileEntry;
+        }
+    }
+}

--- a/TACTBench/Program.cs
+++ b/TACTBench/Program.cs
@@ -1,0 +1,13 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+
+namespace TACTBench
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+            => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/TACTBench/TACTBench.csproj
+++ b/TACTBench/TACTBench.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TACTSharp\TACTSharp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TACTSharp.sln
+++ b/TACTSharp.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TACTSharp", "TACTSharp\TACT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TACTTool", "TACTTool\TACTTool.csproj", "{42BA4C53-C942-4E39-9E25-1134BEE0C4FE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TACTBench", "TACTBench\TACTBench.csproj", "{525CDCD3-3F3F-4E4D-8BD7-5A4BA42400DF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{42BA4C53-C942-4E39-9E25-1134BEE0C4FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{42BA4C53-C942-4E39-9E25-1134BEE0C4FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{42BA4C53-C942-4E39-9E25-1134BEE0C4FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{525CDCD3-3F3F-4E4D-8BD7-5A4BA42400DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{525CDCD3-3F3F-4E4D-8BD7-5A4BA42400DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{525CDCD3-3F3F-4E4D-8BD7-5A4BA42400DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{525CDCD3-3F3F-4E4D-8BD7-5A4BA42400DF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TACTSharp/BLTE.cs
+++ b/TACTSharp/BLTE.cs
@@ -1,6 +1,8 @@
 ﻿using System.Buffers.Binary;
 using System.IO.Compression;
 
+using TACTSharp.Extensions;
+
 namespace TACTSharp
 {
     public static class BLTE

--- a/TACTSharp/Build.cs
+++ b/TACTSharp/Build.cs
@@ -43,7 +43,7 @@ namespace TACTSharp
             {
                 Console.WriteLine("No group index found in CDN config, generating fresh group index...");
                 var groupIndexHash = TACTSharp.GroupIndex.Generate("", CDNConfig.Values["archives"]);
-                var groupIndexPath = Path.Combine("cache", "wow", "data", groupIndexHash + ".index");
+                var groupIndexPath = Path.Combine(Settings.CacheDir, "wow", "data", groupIndexHash + ".index");
                 GroupIndex = new IndexInstance(groupIndexPath);
             }
             else
@@ -54,7 +54,7 @@ namespace TACTSharp
                 }
                 else
                 {
-                    var groupIndexPath = Path.Combine("cache", "wow", "data", groupArchiveIndex[0] + ".index");
+                    var groupIndexPath = Path.Combine(Settings.CacheDir, "wow", "data", groupArchiveIndex[0] + ".index");
                     if (!File.Exists(groupIndexPath))
                         TACTSharp.GroupIndex.Generate(groupArchiveIndex[0], CDNConfig.Values["archives"]);
                     GroupIndex = new IndexInstance(groupIndexPath);

--- a/TACTSharp/CASCIndexInstance.cs
+++ b/TACTSharp/CASCIndexInstance.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Win32.SafeHandles;
 using System.IO.MemoryMappedFiles;
 
+using TACTSharp.Extensions;
+
 namespace TACTSharp
 {
     public sealed class CASCIndexInstance
@@ -90,7 +92,7 @@ namespace TACTSharp
 
                 var indexHigh = entrySpan[header.entryKeyBytes];
                 var indexLow = entrySpan.Slice(header.entryKeyBytes + 1, 4).ReadInt32BE();
-                var indexSize = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(entrySpan.Slice(header.entryKeyBytes + 5, header.entrySizeBytes)) - 30;
+                var indexSize = entrySpan.Slice(header.entryKeyBytes + 5, header.entrySizeBytes).ReadInt32LE() - 30;
 
                 var archiveIndex = (indexHigh << 2 | (byte)((indexLow & 0xC0000000) >> 30));
                 var archiveOffset = (indexLow & 0x3FFFFFFF) + 30;

--- a/TACTSharp/CDN.cs
+++ b/TACTSharp/CDN.cs
@@ -146,7 +146,7 @@ namespace TACTSharp
                 }
             }
 
-            var cachePath = Path.Combine("cache", tprDir, type, hash);
+            var cachePath = Path.Combine(Settings.CacheDir, tprDir, type, hash);
             FileLocks.TryAdd(cachePath, new Lock());
 
             if (File.Exists(cachePath))
@@ -173,7 +173,7 @@ namespace TACTSharp
                 {
                     var url = $"http://{CDNServers[i]}/tpr/{tprDir}/{type}/{hash[0]}{hash[1]}/{hash[2]}{hash[3]}/{hash}";
 
-                    Console.WriteLine("Downloading " + url);
+                    Console.WriteLine("Downloading " + url + " to " + Path.GetFullPath(cachePath));
 
                     var response = await Client.GetAsync(url, token);
                     if (!response.IsSuccessStatusCode)
@@ -267,7 +267,7 @@ namespace TACTSharp
                 }
             }
 
-            var cachePath = Path.Combine("cache", tprDir, "data", eKey);
+            var cachePath = Path.Combine(Settings.CacheDir, tprDir, "data", eKey);
             FileLocks.TryAdd(cachePath, new Lock());
 
             if (File.Exists(cachePath))
@@ -349,7 +349,7 @@ namespace TACTSharp
 
         public static async Task<string> GetFilePath(string tprDir, string type, string hash, ulong compressedSize = 0, CancellationToken token = new())
         {
-            var cachePath = Path.Combine("cache", tprDir, type, hash);
+            var cachePath = Path.Combine(Settings.CacheDir, tprDir, type, hash);
             if (File.Exists(cachePath))
                 return cachePath;
 
@@ -365,7 +365,7 @@ namespace TACTSharp
 
         public static async Task<string> GetDecodedFilePath(string tprDir, string type, string hash, ulong compressedSize = 0, ulong decompressedSize = 0, CancellationToken token = new())
         {
-            var cachePath = Path.Combine("cache", tprDir, type, hash + ".decoded");
+            var cachePath = Path.Combine(Settings.CacheDir, tprDir, type, hash + ".decoded");
             if (File.Exists(cachePath))
                 return cachePath;
 

--- a/TACTSharp/EncodingInstance.cs
+++ b/TACTSharp/EncodingInstance.cs
@@ -87,7 +87,7 @@ namespace TACTSharp
             return result.HasValue;
         }
 
-        public unsafe EncodingResult GetEKeys(Span<byte> cKeyTarget)
+        public unsafe EncodingResult GetEKeys(ReadOnlySpan<byte> cKeyTarget)
         {
             byte* pageData = null;
             mmapViewHandle.AcquirePointer(ref pageData);

--- a/TACTSharp/Extensions/BinarySearchExtensions.cs
+++ b/TACTSharp/Extensions/BinarySearchExtensions.cs
@@ -21,10 +21,10 @@ namespace TACTSharp.Extensions
                 0 => Ordering.Equal,
             };
 
-        public delegate Ordering BinarySearchComparer<T>(scoped ref T left, scoped ref T right) where T : allows ref struct;
+        public delegate Ordering BinarySearchComparer<T, U>(scoped ref T left, U right) where U : allows ref struct;
         public delegate Ordering BinarySearchSpanComparer<T>(ReadOnlySpan<T> left, ReadOnlySpan<T> right);
 
-        /// <inheritdoc cref="BinarySearch{T}(ReadOnlySpan{T}, BinarySearchComparer{T}, ref T)" />
+        /// <inheritdoc cref="BinarySearch{T, U}(ReadOnlySpan{T}, BinarySearchComparer{T, U}, U)" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int BinarySearch<T>(this StridedReadOnlySpan<T> haystack, BinarySearchSpanComparer<T> cmp, ReadOnlySpan<T> needle)
         {
@@ -61,12 +61,13 @@ namespace TACTSharp.Extensions
         /// Performs a binary search on a <paramref name="haystack"/>, returning the index of the <paramref name="needle"/> if possible.
         /// </summary>
         /// <typeparam name="T"></typeparam>
+        /// <typeparam name="U"></typeparam>
         /// <param name="haystack">A buffer of sorted data to sift through.</param>
         /// <param name="cmp">A predicate of the form <c>cmp(<paramref name="haystack"/>[i], <paramref name="needle"/>)</c>.</param>
         /// <param name="needle">The <c>needle</c> to search for.</param>
         /// <returns>The index of the item that was found, or the insertion point that maintains ordering negated.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int BinarySearch<T>(this ReadOnlySpan<T> haystack, BinarySearchComparer<T> cmp, scoped ref T needle)
+        public static int BinarySearch<T, U>(this ReadOnlySpan<T> haystack, BinarySearchComparer<T, U> cmp, U needle)
         {
             var size = haystack.Length;
             var left = 0;
@@ -76,7 +77,7 @@ namespace TACTSharp.Extensions
             {
                 var mid = left + size / 2;
                 // If you need to ask, ReadOnlySpan.Item(int) doesn't allow the return value to be taken by ref.
-                var ordering = cmp(ref Unsafe.Add(ref MemoryMarshal.GetReference(haystack), mid), ref needle);
+                var ordering = cmp(ref Unsafe.Add(ref MemoryMarshal.GetReference(haystack), mid), needle);
 
                 switch (ordering)
                 {
@@ -134,12 +135,13 @@ namespace TACTSharp.Extensions
         /// Searches for the first element in <paramref name="haystack"/> that is <b>not</b> ordered before <paramref name="needle"/>.
         /// </summary>
         /// <typeparam name="T"></typeparam>
+        /// <typeparam name="U"></typeparam>
         /// <param name="haystack">A range of elements to examine.</param>
         /// <param name="cmp">A binary predicate that returns true if the first argument is ordered before the second.</param>
         /// <param name="needle">The value to compare the elements to.</param>
         /// <returns>The index of the first element in range that is not ordered before the needle, or an index past the end.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int LowerBound<T>(this ReadOnlySpan<T> haystack, BinarySearchComparer<T> cmp, ref T needle)
+        public static int LowerBound<T, U>(this ReadOnlySpan<T> haystack, BinarySearchComparer<T, U> cmp, U needle)
         {
             var size = haystack.Length;
             var left = 0;
@@ -148,7 +150,7 @@ namespace TACTSharp.Extensions
             while (left < right)
             {
                 var mid = left + size / 2;
-                var ordering = cmp(ref Unsafe.Add(ref MemoryMarshal.GetReference(haystack), mid), ref needle);
+                var ordering = cmp(ref Unsafe.Add(ref MemoryMarshal.GetReference(haystack), mid), needle);
 
                 switch (ordering)
                 {
@@ -203,12 +205,13 @@ namespace TACTSharp.Extensions
         /// Searches for the first element in <paramref name="haystack"/> that is ordered after <paramref name="needle"/>.
         /// </summary>
         /// <typeparam name="T"></typeparam>
+        /// <typeparam name="U"></typeparam>
         /// <param name="haystack">A range of elements to examine.</param>
         /// <param name="cmp">A binary predicate that returns if the first argument is ordered before the second.</param>
         /// <param name="needle">The value to compare the elements to.</param>
         /// <returns>The index of the first element in range that is not ordered before the needle, or an index past the end.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int UpperBound<T>(this ReadOnlySpan<T> haystack, BinarySearchComparer<T> cmp, ref T needle)
+        public static int UpperBound<T, U>(this ReadOnlySpan<T> haystack, BinarySearchComparer<T, U> cmp, U needle)
         {
             var size = haystack.Length;
             var left = 0;
@@ -217,7 +220,7 @@ namespace TACTSharp.Extensions
             while (left < right)
             {
                 var mid = left + size / 2;
-                var ordering = cmp(ref Unsafe.Add(ref MemoryMarshal.GetReference(haystack), mid), ref needle);
+                var ordering = cmp(ref Unsafe.Add(ref MemoryMarshal.GetReference(haystack), mid), needle);
 
                 switch (ordering)
                 {
@@ -239,15 +242,15 @@ namespace TACTSharp.Extensions
         // ^^^ Upper bound / Array shorthands vvv
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int UpperBound<T>(this T[] haystack, BinarySearchComparer<T> cmp, ref T needle)
-            => UpperBound(haystack.AsSpan(), cmp, ref needle);
+        public static int UpperBound<T, U>(this T[] haystack, BinarySearchComparer<T, U> cmp, U needle)
+            => UpperBound(haystack.AsSpan(), cmp, needle);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int LowerBound<T>(this T[] haystack, BinarySearchComparer<T> cmp, ref T needle)
-            => LowerBound(haystack.AsSpan(), cmp, ref needle);
+        public static int LowerBound<T, U>(this T[] haystack, BinarySearchComparer<T, U> cmp, U needle)
+            => LowerBound(haystack.AsSpan(), cmp, needle);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int BinarySearch<T>(this T[] haystack, BinarySearchComparer<T> cmp, ref T needle)
-            => BinarySearch(haystack.AsSpan(), cmp, ref needle);
+        public static int BinarySearch<T, U>(this T[] haystack, BinarySearchComparer<T, U> cmp, U needle)
+            => BinarySearch(haystack.AsSpan(), cmp, needle);
     }
 }

--- a/TACTSharp/Extensions/SpanExtensions.cs
+++ b/TACTSharp/Extensions/SpanExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,5 +17,22 @@ namespace TACTSharp.Extensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static StridedSpan<T> WithStride<T>(this Span<T> span, int stride)
             => new(span, stride);
+
+        public static ulong ReadUInt64LE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadUInt64LittleEndian(span);
+        public static uint ReadUInt32LE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadUInt32LittleEndian(span);
+        public static ushort ReadUInt16LE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadUInt16LittleEndian(span);
+
+        public static long ReadInt64LE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadInt64LittleEndian(span);
+        public static int ReadInt32LE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadInt32LittleEndian(span);
+        public static short ReadInt16LE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadInt16LittleEndian(span);
+
+        
+        public static ulong ReadUInt64BE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadUInt64BigEndian(span);
+        public static uint ReadUInt32BE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadUInt32BigEndian(span);
+        public static ushort ReadUInt16BE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadUInt16BigEndian(span);
+
+        public static long ReadInt64BE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadInt64BigEndian(span);
+        public static int ReadInt32BE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadInt32BigEndian(span);
+        public static short ReadInt16BE(this ReadOnlySpan<byte> span) => BinaryPrimitives.ReadInt16BigEndian(span);
     }
 }

--- a/TACTSharp/GroupIndex.cs
+++ b/TACTSharp/GroupIndex.cs
@@ -36,7 +36,7 @@ namespace TACTSharp
                 else
                 {
                     _ = CDN.GetFile("wow", "data", archives[archiveIndex] + ".index").Result;
-                    indexPath = Path.Combine("cache", "wow", "data", archives[archiveIndex] + ".index");
+                    indexPath = Path.Combine(Settings.CacheDir, "wow", "data", archives[archiveIndex] + ".index");
                 }
 
                 var index = new IndexInstance(indexPath);
@@ -153,19 +153,19 @@ namespace TACTSharp
                 var fullFooterBytes = br.ReadBytes(28);
                 var fullFooterMD5Hash = Convert.ToHexStringLower(MD5.HashData(fullFooterBytes));
 
-                Directory.CreateDirectory(Path.Combine("cache", "wow", "data"));
+                Directory.CreateDirectory(Path.Combine(Settings.CacheDir, "wow", "data"));
 
                 if (!string.IsNullOrEmpty(hash))
                 {
                     if (fullFooterMD5Hash != hash)
                         throw new Exception("Footer MD5 of group index does not match group index filename");
 
-                    File.WriteAllBytes(Path.Combine("cache", "wow", "data", hash + ".index"), ms.ToArray());
+                    File.WriteAllBytes(Path.Combine(Settings.CacheDir, "wow", "data", hash + ".index"), ms.ToArray());
                 }
                 else
                 {
                     hash = fullFooterMD5Hash;
-                    File.WriteAllBytes(Path.Combine("cache", "wow", "data", fullFooterMD5Hash + ".index"), ms.ToArray());
+                    File.WriteAllBytes(Path.Combine(Settings.CacheDir, "wow", "data", fullFooterMD5Hash + ".index"), ms.ToArray());
                 }
 
                 return hash;

--- a/TACTSharp/IndexInstance.cs
+++ b/TACTSharp/IndexInstance.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Win32.SafeHandles;
 using System.IO.MemoryMappedFiles;
 
+using TACTSharp.Extensions;
+
 namespace TACTSharp
 {
     // mostly based on schlumpf's implementation, but with some changes because i dont know how to port some c++ things to c# properly

--- a/TACTSharp/InstallInstance.cs
+++ b/TACTSharp/InstallInstance.cs
@@ -2,6 +2,8 @@
 using System.Collections;
 using System.IO.MemoryMappedFiles;
 
+using TACTSharp.Extensions;
+
 namespace TACTSharp
 {
     public class InstallInstance

--- a/TACTSharp/RootInstance.cs
+++ b/TACTSharp/RootInstance.cs
@@ -1,30 +1,25 @@
 ﻿using Microsoft.Win32.SafeHandles;
 using System.Buffers.Binary;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO.MemoryMappedFiles;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+using TACTSharp.Extensions;
+
 namespace TACTSharp
 {
-    // THIS IS MOSTLY YOINKED FROM BUILDBACKUP, REMAKE AT SOME POINT
     public class RootInstance
     {
-        private readonly MemoryMappedFile rootFile;
-        private readonly MemoryMappedViewAccessor accessor;
-        private readonly SafeMemoryMappedViewHandle mmapViewHandle;
-
-        private readonly Dictionary<ulong, RootEntry> entriesLookup = [];
-        private readonly Dictionary<uint, RootEntry> entriesFDID = [];
+        private readonly Page[] _pages;
+        private readonly Dictionary<ulong, (int, int)> _hashes = [];
 
         [Flags]
         public enum LocaleFlags : uint
         {
-            All = 0xFFFFFFFF,
-            None = 0,
-            Unk_1 = 0x1,
             enUS = 0x2,
             koKR = 0x4,
-            Unk_8 = 0x8,
             frFR = 0x10,
             deDE = 0x20,
             zhCN = 0x40,
@@ -38,40 +33,21 @@ namespace TACTSharp
             ptBR = 0x4000,
             itIT = 0x8000,
             ptPT = 0x10000,
-            enSG = 0x20000000, // custom
-            plPL = 0x40000000, // custom
-            All_WoW = enUS | koKR | frFR | deDE | zhCN | esES | zhTW | enGB | esMX | ruRU | ptBR | itIT | ptPT
         }
+
+        private static readonly LocaleFlags AllWoW = LocaleFlags.enUS | LocaleFlags.koKR | LocaleFlags.frFR
+            | LocaleFlags.deDE | LocaleFlags.zhCN | LocaleFlags.esES | LocaleFlags.zhTW | LocaleFlags.enGB
+            | LocaleFlags.esMX | LocaleFlags.ruRU | LocaleFlags.ptBR | LocaleFlags.itIT | LocaleFlags.ptPT;
 
         [Flags]
         public enum ContentFlags : uint
         {
             None = 0,
-            F00000001 = 0x1,            // unused in 9.0.5
-            F00000002 = 0x2,            // unused in 9.0.5
-            F00000004 = 0x4,            // unused in 9.0.5
             LoadOnWindows = 0x8,        // added in 7.2.0.23436
             LoadOnMacOS = 0x10,         // added in 7.2.0.23436
             LowViolence = 0x80,         // many models have this flag
             DoNotLoad = 0x100,          // unused in 9.0.5
-            F00000200 = 0x200,          // unused in 9.0.5
-            F00000400 = 0x400,          // unused in 9.0.5
             UpdatePlugin = 0x800,       // UpdatePlugin.dll / UpdatePlugin.dylib only
-            F00001000 = 0x1000,         // unused in 9.0.5
-            F00002000 = 0x2000,         // unused in 9.0.5
-            F00004000 = 0x4000,         // unused in 9.0.5
-            F00008000 = 0x8000,         // unused in 9.0.5
-            F00010000 = 0x10000,        // unused in 9.0.5
-            F00020000 = 0x20000,        // 1173911 uses in 9.0.5        
-            F00040000 = 0x40000,        // 1329023 uses in 9.0.5
-            F00080000 = 0x80000,        // 682817 uses in 9.0.5
-            F00100000 = 0x100000,       // 1231299 uses in 9.0.5
-            F00200000 = 0x200000,       // 7398 uses in 9.0.5: updateplugin, .bls, .lua, .toc, .xsd
-            F00400000 = 0x400000,       // 156302 uses in 9.0.5
-            F00800000 = 0x800000,       // .skel & .wwf
-            F01000000 = 0x1000000,      // unused in 9.0.5
-            F02000000 = 0x2000000,      // 969369 uses in 9.0.5
-            F04000000 = 0x4000000,      // 1101698 uses in 9.0.5
             Encrypted = 0x8000000,      // File is encrypted
             NoNames = 0x10000000,       // No lookup hash
             UncommonRes = 0x20000000,   // added in 7.0.3.21737
@@ -79,13 +55,199 @@ namespace TACTSharp
             NoCompression = 0x80000000  // sounds have this flag
         }
 
-        public struct RootEntry
+        public unsafe RootInstance(string filePath)
         {
-            public ContentFlags contentFlags;
-            public LocaleFlags localeFlags;
-            public ulong lookup;
-            public uint fileDataID;
-            public MD5 md5;
+            var rootFile = MemoryMappedFile.CreateFromFile(filePath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            var accessor = rootFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+            var mmapViewHandle = accessor.SafeMemoryMappedViewHandle;
+
+            byte* rawData = null;
+            mmapViewHandle.AcquirePointer(ref rawData);
+
+            var fileSize = new FileInfo(filePath).Length;
+            var fileData = new ReadOnlySpan<byte>(rawData, (int)fileSize);
+
+            var magic = fileData.ReadUInt32LE();
+            var (format, version, headerSize, totalFileCount, namedFileCount) = magic switch
+            {
+                0x4D465354 => ParseMFST(fileData),
+                _ => (Format.Legacy, 0, 0, 0, 0)
+            };
+
+            // Skip the header.
+            fileData = fileData[headerSize..];
+
+            var pages = new List<Page>();
+            while (fileData.Length != 0)
+            {
+                var recordCount = fileData.ReadInt32LE();
+                fileData = fileData[4..];
+
+                var (contentFlags, localeFlags) = ParseManifestPageFlags(ref fileData, version);
+
+                // No records in this file.
+                if (recordCount == 0)
+                    continue;
+
+                // Calculate block size
+                var blockSize = 4 * recordCount; // FileDataID[n]
+                blockSize += MD5.Length * recordCount;
+                if (format == Format.Legacy || !contentFlags.HasFlag(ContentFlags.NoNames))
+                    blockSize += 8 * recordCount;
+
+                var blockData = fileData[..blockSize];
+                fileData = fileData[blockSize..];
+
+                // Determine conditions related to keeping this page.
+                var localeSkip = !localeFlags.HasFlag(AllWoW) && !localeFlags.HasFlag(Settings.Locale);
+                var contentSkip = contentFlags.HasFlag(ContentFlags.LowViolence);
+
+                if (localeSkip || contentSkip)
+                    continue;
+
+                // Read a FDID delta array from the file (+1 implied) and adjust instantly.
+                var fdids = blockData.ReadUInt32LE(recordCount);
+                for (var i = 1; i < fdids.Length; ++i)
+                    fdids[i] += fdids[i - 1] + 1;
+
+                // Get a span over the actual record block of this page
+                var recordData = blockData[(4 * recordCount)..];
+                var (records, nameHashRange) = format switch
+                {
+                    Format.Legacy => ParseLegacy(recordData, recordCount, fdids),
+                    Format.MFST => ParseManifest(recordData, recordCount, contentFlags, fdids),
+                    _ => throw new UnreachableException()
+                };
+
+                var nameHashes = nameHashRange.AsEnumerator(recordData);
+                var page = new Page(records, contentFlags, localeFlags);
+
+                // TODO: This happens. What do we do?!
+                // System.ArgumentException: An item with the same key has already been added. Key: 11470997404861800962
+                for (var i = 0; i < nameHashes.Count; ++i)
+                    _hashes.TryAdd(nameHashes[i], (pages.Count, i));
+
+                pages.Add(page);
+            }
+            
+            _pages = [.. pages];
+            _hashes.TrimExcess();
+        }
+
+        private static (ContentFlags contentFlags, LocaleFlags localeFlags) ParseManifestPageFlags(ref ReadOnlySpan<byte> fileData, int version)
+        {
+            switch (version)
+            {
+                case 0:
+                case 1:
+                    {
+                        var contentFlags = (ContentFlags)fileData.ReadUInt32LE();
+                        var localeFlags = (LocaleFlags)fileData[4..].ReadUInt32LE();
+
+                        fileData = fileData[(4 + 4) ..];
+
+                        return (contentFlags, localeFlags);
+                    }
+                case 2:
+                    {
+                        var localeFlags = (LocaleFlags)fileData.ReadUInt32LE();
+
+                        var unk1 = fileData[4..].ReadUInt32LE();
+                        var unk2 = fileData[8..].ReadUInt32LE();
+                        var unk3 = ((uint)fileData[12]) << 17;
+
+                        fileData = fileData[13..];
+
+                        var contentFlags = (ContentFlags)(unk1 | unk2 | unk3);
+
+                        return (contentFlags, localeFlags);
+                    }
+                default:
+                    throw new NotImplementedException($"MFST version {version} is not supported");
+            }
+        }
+
+        /// <summary>
+        /// Finds a file given a file data ID.
+        /// </summary>
+        /// <param name="fileDataID">The file data ID to look for.</param>
+        /// <returns>An optional record.</returns>
+        public ref Record FindFileDataID(uint fileDataID)
+        {
+            foreach (ref readonly var page in _pages.AsSpan())
+            {
+                var fdidIndex = page.Records.BinarySearch((ref Record record, int fileDataID) => ((int) record.FileDataID - fileDataID).ToOrdering(), (int) fileDataID);
+                if (fdidIndex < 0)
+                    continue;
+
+                return ref page.Records.UnsafeIndex(fdidIndex);
+            }
+
+            return ref Unsafe.NullRef<Record>();
+        }
+
+        /// <summary>
+        /// Finds a record as identified by its name hash (also known as lookup).
+        /// </summary>
+        /// <param name="nameHash">The hash of the file's complete path in the game's file structure.</param>
+        /// <returns>An optional record.</returns>
+        public ref Record FindHash(ulong nameHash)
+        {
+            if (_hashes.TryGetValue(nameHash, out (int pageIndex, int recordIndex) value))
+            {
+                var page = _pages.UnsafeIndex(value.pageIndex);
+                return ref page.Records.UnsafeIndex(value.recordIndex);
+            }
+
+            return ref Unsafe.NullRef<Record>();
+        }
+
+        private static (Record[], NameHashRange) ParseLegacy(ReadOnlySpan<byte> dataStream, int recordCount, uint[] fdids)
+        {
+            var records = GC.AllocateUninitializedArray<Record>(recordCount);
+            for (var i = 0; i < records.Length; ++i)
+            {
+                var contentKey = new MD5(dataStream[.. MD5.Length]);
+                dataStream = dataStream[(8 + MD5.Length) ..]; // Skip the name hash, we parse it externally
+
+                records[i] = new(contentKey, fdids[i]);
+            }
+
+            return (records, new NameHashRange(0, recordCount * (MD5.Length + 8), MD5.Length + 8, MD5.Length));
+        }
+
+        private static (Record[], NameHashRange) ParseManifest(ReadOnlySpan<byte> dataStream, int recordCount, ContentFlags contentFlags, uint[] fdids)
+        {
+            // Promote the check to an integer (0 or 1) and then multiply by 8. Equivalent to (bool ? 8 : 0) * recordCount.
+            var nameHashSize = (!contentFlags.HasFlag(ContentFlags.NoNames)).UnsafePromote() << 3;
+            nameHashSize *= recordCount;
+
+            var ckr = new Range(0, recordCount * MD5.Length); // Content key range
+            var nhr = new Range(ckr.End.Value, ckr.End.Value + nameHashSize); // Name hash range
+
+            var contentKeys = MemoryMarshal.Cast<byte, MD5>(dataStream[ckr]);
+
+            var records = GC.AllocateUninitializedArray<Record>(recordCount);
+            for (var i = 0; i < recordCount; ++i)
+                records[i] = new(contentKeys[i], fdids[i]);
+
+            return (records, new NameHashRange(nhr.Start.Value, nhr.End.Value, sizeof(ulong)));
+        }
+
+        private static (Format, int Version, int HeaderSize, int TotalFileCount, int NamedFileCount) ParseMFST(ReadOnlySpan<byte> dataStream)
+        {
+            // Skip over magic at dataStream[0]
+            Debug.Assert(dataStream.ReadUInt32LE() == 0x4D465354);
+
+            var headerSize = dataStream[4..].ReadInt32LE();
+            var version = dataStream[8..].ReadInt32LE();
+            if (headerSize > 1000)
+                return (Format.MFST, 0, 4 * 4, headerSize, version);
+
+            var totalFileCount = dataStream[12..].ReadInt32LE();
+            var namedFileCount = dataStream[16..].ReadInt32LE();
+
+            return (Format.MFST, version, headerSize, totalFileCount, namedFileCount);
         }
 
         [InlineArray(16)]
@@ -101,210 +263,39 @@ namespace TACTSharp
             public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref _element, Length);
         }
 
-        public RootEntry? GetEntryByFDID(uint fileDataID)
+        public readonly struct Record(MD5 contentKey, uint fileDataID)
         {
-            if (entriesFDID.TryGetValue(fileDataID, out var entry))
-                return entry;
-
-            return null;
+            public readonly MD5 ContentKey = contentKey;
+            public readonly uint FileDataID = fileDataID;
         }
 
-        public RootEntry? GetEntryByLookup(ulong lookup)
-        {
-            if (entriesLookup.TryGetValue(lookup, out var entry))
-                return entry;
+        private readonly record struct Page(Record[] Records, ContentFlags ContentFlags, LocaleFlags LocaleFlags);
 
-            return null;
+        private enum Format
+        {
+            Legacy,
+            MFST
         }
 
-        public uint[] GetAvailableFDIDs()
+        // A strided range for name hashes.
+        private readonly struct NameHashRange(int start, int end, int stride, int offset = 0)
         {
-            return [.. entriesFDID.Keys];
+            public readonly int Start = start;
+            public readonly int End = end;
+            public readonly int Stride = stride;
+            public readonly int Offset = offset;
+
+            public NameHashEnumerator AsEnumerator(ReadOnlySpan<byte> data)
+                => new(data[Start .. End], Stride, Offset);
         }
 
-        public ulong[] GetAvailableLookups()
+        // Enumerates over a span with a specific stride.
+        private readonly ref struct NameHashEnumerator(ReadOnlySpan<byte> Data, int Stride, int Offset)
         {
-            return [.. entriesLookup.Keys];
-        }
+            private readonly ReadOnlySpan<byte> _data = Data;
+            public readonly int Count => _data.Length / Stride;
 
-        public bool FileExists(ulong lookup)
-        {
-            return entriesLookup.ContainsKey(lookup);
-        }
-
-        public bool FileExists(uint fileDataID)
-        {
-            return entriesFDID.ContainsKey(fileDataID);
-        }
-
-        unsafe public RootInstance(string path)
-        {
-            this.rootFile = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
-            this.accessor = rootFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
-            this.mmapViewHandle = accessor.SafeMemoryMappedViewHandle;
-
-            var namedCount = 0;
-            var unnamedCount = 0;
-            uint totalFiles = 0;
-            uint namedFiles = 0;
-            var newRoot = false;
-            uint dfVersion = 0;
-
-            byte* fileData = null;
-
-            mmapViewHandle.AcquirePointer(ref fileData);
-
-            var rootLength = new FileInfo(path).Length;
-            var rootdata = new ReadOnlySpan<byte>(fileData, (int)rootLength);
-
-            var header = BinaryPrimitives.ReadUInt32LittleEndian(rootdata);
-            int offset = 12;
-
-            if (header == 1296454484)
-            {
-                totalFiles = BinaryPrimitives.ReadUInt32LittleEndian(rootdata.Slice(4, 4));
-                namedFiles = BinaryPrimitives.ReadUInt32LittleEndian(rootdata.Slice(8, 4));
-
-                if (namedFiles == 1 || namedFiles == 2)
-                {
-                    // Post 10.1.7
-                    uint dfHeaderSize = totalFiles;
-                    dfVersion = namedFiles;
-
-                    if (dfVersion == 1 || dfVersion == 2)
-                    {
-                        totalFiles = BinaryPrimitives.ReadUInt32LittleEndian(rootdata.Slice(12, 4));
-                        namedFiles = BinaryPrimitives.ReadUInt32LittleEndian(rootdata.Slice(16, 4));
-                    }
-
-                    offset = (int)dfHeaderSize;
-                }
-
-                newRoot = true;
-            }
-            else
-            {
-                offset = 0;
-            }
-
-            var blockCount = 0;
-
-            while (offset < rootLength)
-            {
-                var count = BinaryPrimitives.ReadUInt32LittleEndian(rootdata.Slice(offset, 4));
-                offset += 4;
-
-                ContentFlags contentFlags;
-                LocaleFlags localeFlags;
-                if (dfVersion == 2)
-                {
-                    localeFlags = (LocaleFlags)BinaryPrimitives.ReadUInt32LittleEndian(rootdata.Slice(offset, 4));
-                    offset += 4;
-
-                    var unkFlags = BinaryPrimitives.ReadUInt32LittleEndian(rootdata.Slice(offset, 4));
-                    offset += 4;
-
-                    var unkFlags2 = BinaryPrimitives.ReadUInt32LittleEndian(rootdata.Slice(offset, 4));
-                    offset += 4;
-
-                    var unkByte = rootdata[offset];
-                    offset++;
-
-                    contentFlags = (ContentFlags)(unkFlags | unkFlags2 | (uint)(unkByte << 17));
-                }
-                else
-                {
-                    contentFlags = (ContentFlags)BinaryPrimitives.ReadUInt32LittleEndian(rootdata.Slice(offset, 4));
-                    offset += 4;
-
-                    localeFlags = (LocaleFlags)BinaryPrimitives.ReadUInt32LittleEndian(rootdata.Slice(offset, 4));
-                    offset += 4;
-                }
-
-                var localeSkip = !localeFlags.HasFlag(LocaleFlags.All_WoW) && !localeFlags.HasFlag(Settings.Locale);
-                var contentSkip = (contentFlags & ContentFlags.LowViolence) != 0;
-
-                var skipChunk = localeSkip || contentSkip;
-
-                bool separateLookup = newRoot;
-                bool doLookup = !newRoot || !contentFlags.HasFlag(ContentFlags.NoNames);
-                int sizeFdid = 4;
-                int sizeCHash = 16;
-                int sizeLookup = 8;
-                int strideFdid = sizeFdid;
-                int strideCHash = !separateLookup ? (sizeCHash + sizeLookup) : sizeCHash;
-                int strideLookup = !separateLookup ? (sizeCHash + sizeLookup) : sizeLookup;
-                int offsetFdid = offset;
-                int offsetCHash = offsetFdid + (int)count * sizeFdid;
-                int offsetLookup = offsetCHash + (!separateLookup ? sizeCHash : ((int)count * sizeCHash));
-                int blockSize = (int)count * (sizeFdid + sizeCHash + (doLookup ? sizeLookup : 0));
-
-                if (!skipChunk)
-                {
-                    uint fileDataIndex = 0;
-                    for (var i = 0; i < count; ++i)
-                    {
-                        RootEntry entry = default;
-                        entry.localeFlags = localeFlags;
-                        entry.contentFlags = contentFlags;
-
-                        uint fileDataIDOffset = (uint)BinaryPrimitives.ReadInt32LittleEndian(rootdata.Slice(offsetFdid, sizeFdid));
-                        offsetFdid += strideFdid;
-
-                        uint filedataIds_i = fileDataIndex + fileDataIDOffset;
-                        entry.fileDataID = filedataIds_i;
-                        fileDataIndex = filedataIds_i + 1;
-
-                        entry.md5 = new(rootdata.Slice(offsetCHash, sizeCHash));
-
-                        offsetCHash += strideCHash;
-
-                        if (doLookup)
-                        {
-                            entry.lookup = BinaryPrimitives.ReadUInt64LittleEndian(rootdata.Slice(offsetLookup, sizeLookup));
-                            offsetLookup += strideLookup;
-                            entriesLookup.TryAdd(entry.lookup, entry);
-                        }
-                        else
-                        {
-                            entry.lookup = 0;
-                        }
-
-                        if (!entriesFDID.TryAdd(entry.fileDataID, entry))
-                        {
-                            //if (!value.md5.SequenceEqual(entries[i].md5))
-                            //{
-                            //    Console.WriteLine("Attempted to add duplicate FDID " + entries[i].fileDataID);
-                            //    Console.WriteLine("\t Existing entry has localeFlags " + value.localeFlags + " and contentFlags " + value.contentFlags + " and ckey " + Convert.ToHexStringLower(value.md5));
-                            //    Console.WriteLine("\t New entry has localeFlags " + entries[i].localeFlags + " and contentFlags " + entries[i].contentFlags + " and ckey " + Convert.ToHexStringLower(entries[i].md5));
-                            //}
-                        }
-                    }
-                }
-
-                offset += blockSize;
-                if (doLookup)
-                {
-                    namedCount += (int)count;
-                }
-                else
-                {
-                    unnamedCount += (int)count;
-                }
-                blockCount++;
-            }
-
-            //if(newRoot)
-            //{
-            //    Console.WriteLine("Read " + entriesFDID.Count + "/" + totalFiles + " total files from root");
-            //    Console.WriteLine("Read " + namedCount + "/" + namedFiles + " named files from root");
-            //}
-            //else
-            //{
-            //    Console.WriteLine("Read " + entriesFDID.Count + " files from root");
-            //}
-
-            mmapViewHandle.ReleasePointer();
+            public readonly ulong this[int index] => _data[((Stride * index) + Offset) ..].ReadUInt64LE();
         }
     }
 }

--- a/TACTSharp/Settings.cs
+++ b/TACTSharp/Settings.cs
@@ -8,5 +8,6 @@
         public static string? BaseDir;
         public static string? BuildConfig;
         public static string? CDNConfig;
+        public static string CacheDir = "~/cache";
     }
 }

--- a/TACTSharp/TACTSharp.csproj
+++ b/TACTSharp/TACTSharp.csproj
@@ -13,6 +13,7 @@
     <IsAotCompatible>True</IsAotCompatible>
   </PropertyGroup>
 
+
   <ItemGroup>
     <Folder Include="Utils\" />
   </ItemGroup>

--- a/TACTSharp/Utils/Extensions.cs
+++ b/TACTSharp/Utils/Extensions.cs
@@ -1,36 +1,72 @@
 ﻿using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
+
+using TACTSharp;
 
 static class Extensions
 {
-    public static ushort ReadUInt16BE(this ReadOnlySpan<byte> source)
-    {
-        return BinaryPrimitives.ReadUInt16BigEndian(source);
-    }
+    /// <summary>
+    /// Returns a given element in an array, bypassing bounds check automatically inserted by the JITter.
+    /// 
+    /// This is semantically equivalen to <pre>arr[index]</pre> but prevents the JIT from emitting bounds checks.
+    /// 
+    /// Note that in return no guarantees are made and you should always make sure the <paramref name="index"/> is within bounds
+    /// yourself.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="arr">The array to index.</param>
+    /// <param name="index">The index of the element to return.</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref T UnsafeIndex<T>(this T[] arr, int index)
+        => ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(arr), index);
 
-    public static short ReadInt16BE(this ReadOnlySpan<byte> source)
+    public static int UnsafePromote(this bool value)
     {
-        return BinaryPrimitives.ReadInt16BigEndian(source);
+#pragma warning disable CS0162 // Unreachable code detected
+        if (sizeof(bool) == sizeof(byte))
+            return (int)Unsafe.As<bool, byte>(ref value);
+        
+        if (sizeof(bool) == sizeof(short))
+            return (int)Unsafe.As<bool, short>(ref value); // ? 8 : 0;
+        
+        if (sizeof(bool) == sizeof(int))
+            return (int)Unsafe.As<bool, int>(ref value); // ? 8 : 0;
+        
+        return value ? 1 : 0;
+#pragma warning restore CS0162 // Unreachable code detected
     }
 
     public static int ReadInt24BE(this ReadOnlySpan<byte> source)
-    {
-        return source[2] | source[1] << 8 | source[0] << 16;
-    }
-
-    public static int ReadInt32BE(this ReadOnlySpan<byte> source)
-    {
-        return BinaryPrimitives.ReadInt32BigEndian(source);
-    }
-
-    public static uint ReadUInt32BE(this ReadOnlySpan<byte> source)
-    {
-        return BinaryPrimitives.ReadUInt32BigEndian(source);
-    }
+        => source[2] | source[1] << 8 | source[0] << 16;
 
     public static long ReadInt40BE(this ReadOnlySpan<byte> source)
+        => source[4] | source[3] << 8 | source[2] << 16 | source[1] << 24 | source[0] << 32;
+
+    public static int[] ReadInt32LE(this ReadOnlySpan<byte> source, int count)
     {
-        return source[4] | source[3] << 8 | source[2] << 16 | source[1] << 24 | source[0] << 32;
+        var data = MemoryMarshal.Cast<byte, int>(source[0..(count * 4)]).ToArray();
+
+        if (!BitConverter.IsLittleEndian)
+        {
+            for (var i = 0; i < data.Length; ++i)
+                data[i] = BinaryPrimitives.ReverseEndianness(data[i]);
+        }
+        return data;
+    }
+
+    public static uint[] ReadUInt32LE(this ReadOnlySpan<byte> source, int count)
+    {
+        var data = MemoryMarshal.Cast<byte, uint>(source[0..(count * 4)]).ToArray();
+
+        if (!BitConverter.IsLittleEndian)
+        {
+            for (var i = 0; i < data.Length; ++i)
+                data[i] = BinaryPrimitives.ReverseEndianness(data[i]);
+        }
+        return data;
     }
 
     public static string ReadNullTermString(this ReadOnlySpan<byte> source)

--- a/TACTTool/Program.cs
+++ b/TACTTool/Program.cs
@@ -353,14 +353,14 @@ namespace TACTTool
                 return;
             }
 
-            var fileEntry = build.Root.GetEntryByFDID(fileDataID);
-            if (fileEntry == null)
+            ref var fileEntry = ref build.Root.FindFileDataID(fileDataID);
+            if (Unsafe.IsNullRef(in fileEntry))
             {
                 Console.WriteLine("Skipping FDID " + fdid + ", not found in root.");
                 return;
             }
 
-            if (!build.Encoding.TryGetEKeys(fileEntry.Value.md5.AsSpan(), out var fileEKeys) || fileEKeys == null)
+            if (!build.Encoding.TryGetEKeys(fileEntry.ContentKey.AsSpan(), out var fileEKeys) || fileEKeys == null)
             {
                 Console.WriteLine("Skipping FDID " + fdid + ", CKey not found in encoding.");
                 return;


### PR DESCRIPTION
![](https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fek8ibksmzjcg7omtndib.jpg)

> [!CAUTION]
> This conflicts with the [encoding](https://github.com/wowdev/TACTSharp/pull/2) PR. I'll fix the conflicts depending on the merge order. Specifically the binary search bits.

```diff
 Configs loaded in 5ms
 Group index loaded in 2ms
 File index loaded in 1ms
 Encoding loaded in 2ms
-Root loaded in 245ms
+Root loaded in 58ms
 Install loaded in 3ms
```

This project would probably need benchmarks at some point but this obviously a win. Measurements done with `dotnet run` so AOT is not even a factor (38ms on my machine if running the published binary)

```
dotnet run -c Release --project TACTTool -- -p wow -m fdid -i 1439477
```

Note: I'm down to remove the weird name hash handling because the only reason it's there is to reduce RAM usage of root entries (no name hash stored anymore, wowee!) it has almost no speed impact on my machine.

Name hash collision when setting up the reverse lookup for that is an issue and should probably be combined with locale and content flags, but I feel like that is an issue that can be adressed later.

```diff
# Linux, arm64, published binaries:
 Configs loaded in 4ms
 Group index loaded in 1ms
 File index loaded in 1ms
 Encoding loaded in 1ms
-Root loaded in 189ms
+Root loaded in 32ms
 Install loaded in 1ms
-Build WOW-58773patch11.0.7_Retail loaded in 193ms
+Build WOW-58773patch11.0.7_Retail loaded in 36ms
 Extracting 1 file..
 Extracting c722f37c2ef5828846f346df398f8273 to 1439477
-Total time: 194.1482m
+Total time: 36.4885ms
        Command being timed: "./TACTTool -p wow -m fdid -i 1439477"
        User time (seconds): 0.07
        System time (seconds): 0.04
        Percent of CPU this job got: 17%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.65
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 104608
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 13658
        Voluntary context switches: 39
        Involuntary context switches: 4
        Swaps: 0
        File system inputs: 0
        File system outputs: 600
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```