### PR TITLE
Span-ify encoding.

### DIFF
--- a/TACTSharp/Build.cs
+++ b/TACTSharp/Build.cs
@@ -90,7 +90,7 @@
             if (!Encoding.TryGetEKeys(Convert.FromHexString(rootKey[0]), out var rootEKeys) || rootEKeys == null)
                 throw new Exception("Root key not found in encoding");
 
-            Root = new RootInstance(await CDN.GetDecodedFilePath("wow", "data", Convert.ToHexStringLower(rootEKeys.Value.eKeys[0]), 0, rootEKeys.Value.decodedFileSize));
+            Root = new RootInstance(await CDN.GetDecodedFilePath("wow", "data", Convert.ToHexStringLower(rootEKeys.Value[0]), 0, rootEKeys.Value.DecodedFileSize));
             timer.Stop();
             Console.WriteLine("Root loaded in " + Math.Ceiling(timer.Elapsed.TotalMilliseconds) + "ms");
 
@@ -101,7 +101,7 @@
             if (!Encoding.TryGetEKeys(Convert.FromHexString(installKey[0]), out var installEKeys) || installEKeys == null)
                 throw new Exception("Install key not found in encoding");
 
-            Install = new InstallInstance(await CDN.GetDecodedFilePath("wow", "data", Convert.ToHexStringLower(installEKeys.Value.eKeys[0]), 0, installEKeys.Value.decodedFileSize));
+            Install = new InstallInstance(await CDN.GetDecodedFilePath("wow", "data", Convert.ToHexStringLower(installEKeys.Value[0]), 0, installEKeys.Value.DecodedFileSize));
             timer.Stop();
             Console.WriteLine("Install loaded in " + Math.Ceiling(timer.Elapsed.TotalMilliseconds) + "ms");
         }
@@ -123,14 +123,16 @@
             if (Encoding == null)
                 throw new Exception("Encoding not loaded");
 
-            var encodingResult = Encoding.GetEKeys(cKey) ?? throw new Exception("File not found in encoding");
+            var encodingResult = Encoding.GetEKeys(cKey);
+            if (encodingResult.Length == 0)
+                throw new Exception("File not found in encoding");
 
-            return OpenFileByEKey(encodingResult.eKeys[0], encodingResult.decodedFileSize);
+            return OpenFileByEKey(encodingResult[0], encodingResult.DecodedFileSize);
         }
 
         public byte[] OpenFileByEKey(string eKey, ulong decodedSize = 0) => OpenFileByEKey(Convert.FromHexString(eKey), decodedSize);
 
-        public byte[] OpenFileByEKey(byte[] eKey, ulong decodedSize = 0)
+        public byte[] OpenFileByEKey(ReadOnlySpan<byte> eKey, ulong decodedSize = 0)
         {
             if (GroupIndex == null || FileIndex == null)
                 throw new Exception("Indexes not loaded");

--- a/TACTSharp/Build.cs
+++ b/TACTSharp/Build.cs
@@ -78,8 +78,9 @@
             timer.Stop();
             Console.WriteLine("File index loaded in " + Math.Ceiling(timer.Elapsed.TotalMilliseconds) + "ms");
 
+            var encodingSize = ulong.Parse(BuildConfig.Values["encoding-size"][0]);
             timer.Restart();
-            Encoding = new EncodingInstance(await CDN.GetDecodedFilePath("wow", "data", BuildConfig.Values["encoding"][1], ulong.Parse(BuildConfig.Values["encoding-size"][1]), ulong.Parse(BuildConfig.Values["encoding-size"][0])));
+            Encoding = new EncodingInstance(await CDN.GetDecodedFilePath("wow", "data", BuildConfig.Values["encoding"][1], ulong.Parse(BuildConfig.Values["encoding-size"][1]), encodingSize), encodingSize);
             timer.Stop();
             Console.WriteLine("Encoding loaded in " + Math.Ceiling(timer.Elapsed.TotalMilliseconds) + "ms");
 

--- a/TACTSharp/EncodingInstance.cs
+++ b/TACTSharp/EncodingInstance.cs
@@ -1,83 +1,80 @@
 ﻿using Microsoft.Win32.SafeHandles;
+
+using System.Diagnostics;
 using System.IO.MemoryMappedFiles;
+
+using TACTSharp.Extensions;
+
+using static TACTSharp.Extensions.BinarySearchExtensions;
 
 namespace TACTSharp
 {
     public class EncodingInstance
     {
+        private readonly string _filePath;
         private readonly MemoryMappedFile encodingFile;
         private readonly MemoryMappedViewAccessor accessor;
         private readonly SafeMemoryMappedViewHandle mmapViewHandle;
-        private EncodingHeader header;
-        private string[] ESpecs = [];
-        private readonly Lock ESpecLock = new();
+        private EncodingSchema _header;
+        private string[] _encodingSpecs = [];
+        private readonly Lock _encodingSpecsLock = new();
+
+        public static readonly EncodingResult Zero = new(0, [], 0);
 
         public EncodingInstance(string path)
         {
+            _filePath = path;
+
             this.encodingFile = MemoryMappedFile.CreateFromFile(path, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
             this.accessor = encodingFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
             this.mmapViewHandle = accessor.SafeMemoryMappedViewHandle;
 
-            this.header = ReadHeader();
+            (var version, _header) = ReadHeader();
 
-            if (this.header.version != 1)
+            if (version != 1)
                 throw new Exception("Unsupported encoding version");
-
-            if (this.header.hashSizeCKey != 0x10)
-                throw new Exception("Unsupported CKey hash size");
-
-            if (this.header.hashSizeEKey != 0x10)
-                throw new Exception("Unsupported EKey hash size");
         }
 
-        unsafe private EncodingHeader ReadHeader()
+        unsafe private (byte Version, EncodingSchema Schema) ReadHeader()
         {
             byte* headerData = null;
-
-            mmapViewHandle.AcquirePointer(ref headerData);
-
-            var header = new ReadOnlySpan<byte>(headerData, 22);
-
-            if (header[0] != 0x45 || header[1] != 0x4E)
-                throw new Exception("Invalid encoding file magic");
-
-            return new EncodingHeader
+            try
             {
-                version = header[2],
-                hashSizeCKey = header[3],
-                hashSizeEKey = header[4],
-                CKeyPageSizeKB = (ushort)((header[5] << 8) | header[6]),
-                EKeySpecPageSizeKB = (ushort)((header[7] << 8) | header[8]),
-                CEKeyPageTablePageCount = (uint)((header[9] << 24) | (header[10] << 16) | (header[11] << 8) | header[12]),
-                EKeySpecPageTablePageCount = (uint)((header[13] << 24) | (header[14] << 16) | (header[15] << 8) | header[16]),
-                unk11 = header[17],
-                ESpecBlockSize = (uint)((header[18] << 24) | (header[19] << 16) | (header[20] << 8) | header[21])
-            };
-        }
+                mmapViewHandle.AcquirePointer(ref headerData);
 
-        unsafe static private byte* LowerBoundEkey(byte* begin, byte* end, long dataSize, ReadOnlySpan<byte> needle)
-        {
-            var count = (end - begin) / dataSize;
+                var header = new ReadOnlySpan<byte>(headerData, 22);
+                if (header[0] != 0x45 || header[1] != 0x4E)
+                    throw new Exception("Invalid encoding file magic");
 
-            while (count > 0)
-            {
-                var it = begin;
-                var step = count / 2;
-                it += step * dataSize;
+                var version = header[0x02];
+                var hashSizeCKey = header[0x03];
+                var hashSizeEKey = header[0x04];
+                var ckeyPageSize = header[0x05..].ReadUInt16BE() * 1024;
+                var ekeyPageSize = header[0x07..].ReadUInt16BE() * 1024;
+                var ckeyPageCount = header[0x09..].ReadInt32BE();
+                var ekeyPageCount = header[0x0D..].ReadInt32BE();
+                Debug.Assert(header[0x11] == 0x00);
+                var especBlockSize = header[0x12..].ReadInt32BE();
 
-                if (new ReadOnlySpan<byte>(it, needle.Length).SequenceCompareTo(needle) <= 0)
-                {
-                    it += dataSize;
-                    begin = it;
-                    count -= step + 1;
-                }
-                else
-                {
-                    count = step;
-                }
+                var especRange = new Range(22, 22 + especBlockSize);
+                var ckeyHeaderRange = new Range(especRange.End, especRange.End.Value + ckeyPageCount * (hashSizeCKey + 0x10));
+                var ckeyRange = new Range(ckeyHeaderRange.End, ckeyHeaderRange.End.Value + ckeyPageSize * ckeyPageCount);
+                var ekeyHeaderRange = new Range(ckeyRange.End, ckeyRange.End.Value + ekeyPageCount * (hashSizeEKey + 0x10));
+                var ekeyRange = new Range(ekeyHeaderRange.End, ekeyHeaderRange.End.Value + ekeyPageSize * ekeyPageCount);
+
+                return (version, new EncodingSchema(
+                    hashSizeCKey,
+                    hashSizeEKey,
+                    especRange,
+                    new(ckeyHeaderRange, ckeyRange, hashSizeCKey + 0x10, ckeyPageSize),
+                    new(ekeyHeaderRange, ekeyRange, hashSizeEKey + 0x10, ekeyPageSize)
+                ));
             }
-
-            return begin;
+            finally
+            {
+                if (headerData != null)
+                    mmapViewHandle.ReleasePointer();
+            }
         }
 
         public bool TryGetEKeys(Span<byte> cKeyTarget, out EncodingResult? result)
@@ -86,158 +83,118 @@ namespace TACTSharp
             return result.HasValue;
         }
 
-        public unsafe EncodingResult? GetEKeys(Span<byte> cKeyTarget)
+        public unsafe EncodingResult GetEKeys(Span<byte> cKeyTarget)
         {
             byte* pageData = null;
             mmapViewHandle.AcquirePointer(ref pageData);
 
-            var eKeyPageSize = header.EKeySpecPageSizeKB * 1024;
-
-            byte* startOfPageKeys = pageData + 22 + header.ESpecBlockSize;
-            byte* endOfPageKeys = startOfPageKeys + (header.CEKeyPageTablePageCount * 32);
-
-            byte* lastPageKey = LowerBoundEkey(startOfPageKeys, endOfPageKeys, 32, cKeyTarget);
-            if (lastPageKey == startOfPageKeys)
-                return null;
-
-            var pageIndex = ((lastPageKey - startOfPageKeys) / 32) - 1;
-            var startOfPageEKeys = endOfPageKeys + ((int)pageIndex * eKeyPageSize);
-            var targetPage = new ReadOnlySpan<byte>(startOfPageEKeys, eKeyPageSize);
-            var offs = 0;
-            while (true)
+            ReadOnlySpan<byte> fileData = new(pageData, (int) new FileInfo(_filePath).Length);
+            var targetPage = _header.CEKey.ResolvePage(fileData, cKeyTarget);
+            while (targetPage.Length != 0)
             {
-                if (offs >= eKeyPageSize)
-                    break;
+                var keyCount = targetPage[0];
+                var recordData = targetPage.Slice(1, 5 + _header.CKeySize + _header.EKeySize * keyCount);
 
-                var eKeyCount = targetPage[offs];
-                offs++;
+                // Advance iteration
+                targetPage = targetPage[(recordData.Length + 1) ..];
 
-                if (eKeyCount == 0)
+                if (keyCount == 0)
                     continue;
 
-                if (targetPage.Slice(offs + 5, header.hashSizeCKey).SequenceEqual(cKeyTarget))
+                var recordContentKey = recordData.Slice(5, _header.CKeySize);
+                var recordEncodingKeys = recordData.Slice(5 + _header.CKeySize, _header.EKeySize * keyCount);
+
+                if (recordContentKey.SequenceEqual(cKeyTarget))
                 {
-                    var decodedFileSize = (ulong)targetPage.Slice(offs, 5).ReadInt40BE();
-                    offs += 5;
-
-                    offs += header.hashSizeCKey; // +ckey
-
-                    var eKeys = new List<byte[]>(eKeyCount);
-                    for (var i = 0; i < eKeyCount; i++)
-                    {
-                        var eKey = new byte[header.hashSizeEKey];
-                        targetPage.Slice(offs, header.hashSizeEKey).CopyTo(eKey);
-                        offs += header.hashSizeEKey;
-                        eKeys.Add(eKey);
-                    }
-
-                    return new EncodingResult()
-                    {
-                        eKeyCount = eKeyCount,
-                        decodedFileSize = decodedFileSize,
-                        eKeys = eKeys
-                    };
-                }
-                else
-                {
-                    offs += 5; //+size
-                    offs += header.hashSizeCKey; // +ckey
-                    offs += header.hashSizeEKey * eKeyCount; // +ekeys
+                    var decodedFileSize = (ulong)recordData.ReadInt40BE();
+                    return new EncodingResult(keyCount, recordEncodingKeys, decodedFileSize);
                 }
             }
 
-            return null;
+            return EncodingResult.Empty;
         }
 
-        public unsafe (string eSpec, ulong encodedFileSize)? GetESpec(Span<byte> eKeyTarget)
+        public unsafe (string eSpec, ulong encodedFileSize) GetESpec(Span<byte> eKeyTarget)
         {
             byte* pageData = null;
             mmapViewHandle.AcquirePointer(ref pageData);
-            lock (ESpecLock)
+
+            ReadOnlySpan<byte> fileData = new(pageData, (int) new FileInfo(_filePath).Length);
+
+            lock (_encodingSpecsLock)
             {
-                if (ESpecs.Length == 0)
+                if (_encodingSpecs.Length == 0)
                 {
                     var timer = new System.Diagnostics.Stopwatch();
                     timer.Start();
                     var eSpecs = new List<string>();
 
-                    var eSpecTable = new ReadOnlySpan<byte>(pageData + 22, (int)header.ESpecBlockSize);
-                    var eSpecOffs = 0;
-                    while (true)
-                    {
-                        if (eSpecOffs >= header.ESpecBlockSize)
-                            break;
+                    var eSpecTable = fileData[_header.EncodingSpec];
 
-                        var eSpecString = eSpecTable[eSpecOffs..].ReadNullTermString();
-                        eSpecOffs += eSpecString.Length + 1;
+                    while (eSpecTable.Length != 0)
+                    {
+                        var eSpecString = eSpecTable.ReadNullTermString();
+                        eSpecTable = eSpecTable[(eSpecString.Length + 1)..];
                         eSpecs.Add(eSpecString);
                     }
 
-                    ESpecs = [.. eSpecs];
+                    _encodingSpecs = [.. eSpecs];
                     timer.Stop();
-                    Console.WriteLine("Loaded " + ESpecs.Length + " ESpecs in " + timer.Elapsed.TotalMilliseconds + "ms");
+                    Console.WriteLine("Loaded " + _encodingSpecs.Length + " ESpecs in " + timer.Elapsed.TotalMilliseconds + "ms");
                 }
             }
 
-            var eKeyPageSize = header.EKeySpecPageSizeKB * 1024;
-
-            byte* startOfESpecPageKeys = pageData + 22 + header.ESpecBlockSize + (header.CEKeyPageTablePageCount * 32) + (header.CEKeyPageTablePageCount * (header.CKeyPageSizeKB * 1024));
-            byte* endOfESpecPageKeys = startOfESpecPageKeys + (header.EKeySpecPageTablePageCount * 32);
-
-            byte* firstESpecPageKey = LowerBoundEkey(startOfESpecPageKeys, endOfESpecPageKeys, 32, eKeyTarget);
-            if (firstESpecPageKey == startOfESpecPageKeys)
-                return null;
-
-            var pageIndex = ((firstESpecPageKey - startOfESpecPageKeys) / 32) - 1;
-            var startOfPageESpec = endOfESpecPageKeys + ((int)pageIndex * eKeyPageSize);
-            var targetPage = new ReadOnlySpan<byte>(startOfPageESpec, eKeyPageSize);
-            var offs = 0;
-            while (true)
+            var targetPage = _header.EKeySpec.ResolvePage(fileData, eKeyTarget);
+            while (targetPage.Length != 0)
             {
-                if (offs >= eKeyPageSize)
-                    break;
-
-                if (targetPage.Slice(offs, header.hashSizeEKey).SequenceEqual(eKeyTarget))
+                if (targetPage[.._header.EKeySize].SequenceEqual(eKeyTarget))
                 {
-                    offs += header.hashSizeEKey; // +ekey
+                    var specIndex = targetPage.Slice(_header.EKeySize).ReadInt32BE();
+                    var encodedFileSize = (ulong) targetPage.Slice(_header.EKeySize + 4).ReadInt40BE();
 
-                    var eSpecIndex = targetPage.Slice(offs, 4).ReadInt32BE();
-                    offs += 4;
-
-                    var encodedFileSize = (ulong)targetPage.Slice(offs, 5).ReadInt40BE();
-
-                    return (ESpecs[eSpecIndex], encodedFileSize);
+                    return (_encodingSpecs[specIndex], encodedFileSize);
                 }
                 else
                 {
-                    offs += header.hashSizeEKey; // +ekey
-                    offs += 4; // +encodedFileSize
-                    offs += 5; // +encodedFileSize
+                    targetPage = targetPage[.. (_header.EKeySize + 4 + 5)];
                 }
             }
 
-            return null;
+            return (string.Empty, 0);
         }
 
-        private unsafe struct EncodingHeader
+        public readonly struct EncodingResult(byte keyCount, ReadOnlySpan<byte> keys, ulong fileSize)
         {
-            public fixed byte magic[2];
-            public byte version;
-            public byte hashSizeEKey;
-            public byte hashSizeCKey;
-            public ushort CKeyPageSizeKB;
-            public ushort EKeySpecPageSizeKB;
-            public uint CEKeyPageTablePageCount;
-            public uint EKeySpecPageTablePageCount;
-            public byte unk11;
-            public uint ESpecBlockSize;
+            private readonly byte[] _keys = keys.ToArray();
+            private readonly int _keyLength = keys.Length / keyCount;
+
+            public readonly ulong DecodedFileSize = fileSize;
+            public readonly ReadOnlySpan<byte> this[int index] => _keys.AsSpan().Slice(_keyLength * index, _keyLength);
+            public readonly int Length => _keys.Length;
+
+            public static readonly EncodingResult Empty = new (0, [], 0);
         }
 
-        public struct EncodingResult
+        private readonly record struct EncodingSchema(int CKeySize, int EKeySize, Range EncodingSpec, TableSchema CEKey, TableSchema EKeySpec);
+        private readonly struct TableSchema(Range header, Range pages, int headerEntrySize, int pageSize)
         {
-            public byte eKeyCount;
-            public ulong decodedFileSize;
-            public List<byte[]> eKeys;
+            private readonly Range _header = header;
+            private readonly Range _pages = pages;
+            private readonly int _headerEntrySize = headerEntrySize;
+            private readonly int _pageSize = pageSize;
+
+            public readonly ReadOnlySpan<byte> ResolvePage(ReadOnlySpan<byte> fileData, ReadOnlySpan<byte> xKey)
+            {
+                var entryIndex = fileData[_header].WithStride(_headerEntrySize).LowerBound((itr, needle) =>
+                {
+                    return itr[..needle.Length].SequenceCompareTo(needle).ToOrdering();
+                }, xKey);
+
+                if (entryIndex * _headerEntrySize > _header.End.Value)
+                    return [];
+
+                return fileData.Slice(_pages.Start.Value + _pageSize * (entryIndex - 1), _pageSize);
+            }
         }
     }
 }

--- a/TACTSharp/Extensions/BinarySearchExtensions.cs
+++ b/TACTSharp/Extensions/BinarySearchExtensions.cs
@@ -240,8 +240,7 @@ namespace TACTSharp.Extensions
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int UpperBound<T>(this T[] haystack, BinarySearchComparer<T> cmp, ref T needle)
-            => LowerBound(haystack.AsSpan(), cmp, ref needle);
-
+            => UpperBound(haystack.AsSpan(), cmp, ref needle);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LowerBound<T>(this T[] haystack, BinarySearchComparer<T> cmp, ref T needle)

--- a/TACTSharp/Extensions/BinarySearchExtensions.cs
+++ b/TACTSharp/Extensions/BinarySearchExtensions.cs
@@ -1,0 +1,254 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TACTSharp.Extensions
+{
+    internal static class BinarySearchExtensions
+    {
+        public enum Ordering
+        {
+            Less,
+            Equal,
+            Greater,
+        }
+
+        public static Ordering ToOrdering(this int comparison)
+            => comparison switch
+            {
+                > 0 => Ordering.Greater,
+                < 0 => Ordering.Less,
+                0 => Ordering.Equal,
+            };
+
+        public delegate Ordering BinarySearchComparer<T>(scoped ref T left, scoped ref T right) where T : allows ref struct;
+        public delegate Ordering BinarySearchSpanComparer<T>(ReadOnlySpan<T> left, ReadOnlySpan<T> right);
+
+        /// <inheritdoc cref="BinarySearch{T}(ReadOnlySpan{T}, BinarySearchComparer{T}, ref T)" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int BinarySearch<T>(this StridedReadOnlySpan<T> haystack, BinarySearchSpanComparer<T> cmp, ReadOnlySpan<T> needle)
+        {
+            var size = haystack.Count;
+            var left = 0;
+            var right = size;
+
+            while (left < right)
+            {
+                var mid = left + size / 2;
+                var ordering = cmp(haystack[mid], needle);
+
+                switch (ordering)
+                {
+                    case Ordering.Less:
+                        left = mid + 1;
+                        break;
+                    case Ordering.Greater:
+                        right = mid;
+                        break;
+                    case Ordering.Equal:
+                        Debug.Assert(mid < haystack.Count);
+                        return mid;
+                }
+
+                size = right - left;
+            }
+
+            Debug.Assert(left <= haystack.Count);
+            return -(left + 1);
+        }
+
+        /// <summary>
+        /// Performs a binary search on a <paramref name="haystack"/>, returning the index of the <paramref name="needle"/> if possible.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="haystack">A buffer of sorted data to sift through.</param>
+        /// <param name="cmp">A predicate of the form <c>cmp(<paramref name="haystack"/>[i], <paramref name="needle"/>)</c>.</param>
+        /// <param name="needle">The <c>needle</c> to search for.</param>
+        /// <returns>The index of the item that was found, or the insertion point that maintains ordering negated.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int BinarySearch<T>(this ReadOnlySpan<T> haystack, BinarySearchComparer<T> cmp, scoped ref T needle)
+        {
+            var size = haystack.Length;
+            var left = 0;
+            var right = size;
+
+            while (left < right)
+            {
+                var mid = left + size / 2;
+                // If you need to ask, ReadOnlySpan.Item(int) doesn't allow the return value to be taken by ref.
+                var ordering = cmp(ref Unsafe.Add(ref MemoryMarshal.GetReference(haystack), mid), ref needle);
+
+                switch (ordering)
+                {
+                    case Ordering.Less:
+                        left = mid + 1;
+                        break;
+                    case Ordering.Greater:
+                        right = mid;
+                        break;
+                    case Ordering.Equal:
+                        Debug.Assert(mid < haystack.Length);
+                        return mid;
+                }
+
+                size = right - left;
+            }
+
+            Debug.Assert(left <= haystack.Length);
+            return -(left + 1);
+        }
+
+        // ^^^ Binary search / Lower bound vvv
+
+        /// <inheritdoc cref="LowerBound{T}(ReadOnlySpan{T}, BinarySearchComparer{T}, ref T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int LowerBound<T>(this StridedReadOnlySpan<T> haystack, BinarySearchSpanComparer<T> cmp, ReadOnlySpan<T> needle)
+        {
+            var size = haystack.Count;
+            var left = 0;
+            var right = size;
+
+            while (left < right)
+            {
+                var mid = left + size / 2;
+                var ordering = cmp(haystack[mid], needle);
+
+                switch (ordering)
+                {
+                    case Ordering.Less:
+                        left = mid + 1;
+                        break;
+                    case Ordering.Greater:
+                    case Ordering.Equal:
+                        right = mid;
+                        break;
+                }
+
+                size = right - left;
+            }
+
+            return left;
+        }
+
+        /// <summary>
+        /// Searches for the first element in <paramref name="haystack"/> that is <b>not</b> ordered before <paramref name="needle"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="haystack">A range of elements to examine.</param>
+        /// <param name="cmp">A binary predicate that returns true if the first argument is ordered before the second.</param>
+        /// <param name="needle">The value to compare the elements to.</param>
+        /// <returns>The index of the first element in range that is not ordered before the needle, or an index past the end.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int LowerBound<T>(this ReadOnlySpan<T> haystack, BinarySearchComparer<T> cmp, ref T needle)
+        {
+            var size = haystack.Length;
+            var left = 0;
+            var right = size;
+
+            while (left < right)
+            {
+                var mid = left + size / 2;
+                var ordering = cmp(ref Unsafe.Add(ref MemoryMarshal.GetReference(haystack), mid), ref needle);
+
+                switch (ordering)
+                {
+                    case Ordering.Less:
+                        left = mid + 1;
+                        break;
+                    case Ordering.Greater:
+                    case Ordering.Equal:
+                        right = mid;
+                        break;
+                }
+
+                size = right - left;
+            }
+
+            return left;
+        }
+
+        // ^^^ Lower bound / Upper bound vvv
+
+        /// <inheritdoc cref="UpperBound{T}(ReadOnlySpan{T}, BinarySearchComparer{T}, ref T)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int UpperBound<T>(this StridedReadOnlySpan<T> haystack, BinarySearchSpanComparer<T> cmp, ReadOnlySpan<T> needle)
+        {
+            var size = haystack.Count;
+            var left = 0;
+            var right = size;
+
+            while (left < right)
+            {
+                var mid = left + size / 2;
+                var ordering = cmp(haystack[mid], needle);
+
+                switch (ordering)
+                {
+                    case Ordering.Greater:
+                        left = mid + 1;
+                        break;
+                    case Ordering.Less:
+                    case Ordering.Equal:
+                        right = mid;
+                        break;
+                }
+
+                size = right - left;
+            }
+
+            return left;
+        }
+
+        /// <summary>
+        /// Searches for the first element in <paramref name="haystack"/> that is ordered after <paramref name="needle"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="haystack">A range of elements to examine.</param>
+        /// <param name="cmp">A binary predicate that returns if the first argument is ordered before the second.</param>
+        /// <param name="needle">The value to compare the elements to.</param>
+        /// <returns>The index of the first element in range that is not ordered before the needle, or an index past the end.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int UpperBound<T>(this ReadOnlySpan<T> haystack, BinarySearchComparer<T> cmp, ref T needle)
+        {
+            var size = haystack.Length;
+            var left = 0;
+            var right = size;
+
+            while (left < right)
+            {
+                var mid = left + size / 2;
+                var ordering = cmp(ref Unsafe.Add(ref MemoryMarshal.GetReference(haystack), mid), ref needle);
+
+                switch (ordering)
+                {
+                    case Ordering.Greater:
+                        left = mid + 1;
+                        break;
+                    case Ordering.Less:
+                    case Ordering.Equal:
+                        right = mid;
+                        break;
+                }
+
+                size = right - left;
+            }
+
+            return left;
+        }
+
+        // ^^^ Upper bound / Array shorthands vvv
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int UpperBound<T>(this T[] haystack, BinarySearchComparer<T> cmp, ref T needle)
+            => LowerBound(haystack.AsSpan(), cmp, ref needle);
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int LowerBound<T>(this T[] haystack, BinarySearchComparer<T> cmp, ref T needle)
+            => LowerBound(haystack.AsSpan(), cmp, ref needle);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int BinarySearch<T>(this T[] haystack, BinarySearchComparer<T> cmp, ref T needle)
+            => BinarySearch(haystack.AsSpan(), cmp, ref needle);
+    }
+}

--- a/TACTSharp/Extensions/SpanExtensions.cs
+++ b/TACTSharp/Extensions/SpanExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TACTSharp.Extensions
+{
+    internal static class SpanExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static StridedReadOnlySpan<T> WithStride<T>(this ReadOnlySpan<T> span, int stride)
+            => new(span, stride);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static StridedSpan<T> WithStride<T>(this Span<T> span, int stride)
+            => new(span, stride);
+    }
+}

--- a/TACTSharp/IndexInstance.cs
+++ b/TACTSharp/IndexInstance.cs
@@ -109,7 +109,7 @@ namespace TACTSharp
             return entries;
         }
 
-        unsafe public (int offset, int size, int archiveIndex) GetIndexInfo(Span<byte> eKeyTarget)
+        unsafe public (int offset, int size, int archiveIndex) GetIndexInfo(ReadOnlySpan<byte> eKeyTarget)
         {
             byte* fileData = null;
             try

--- a/TACTSharp/StridedSpan.cs
+++ b/TACTSharp/StridedSpan.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TACTSharp
+{
+    internal readonly ref struct StridedSpan<T>(Span<T> data, int stride)
+    {
+        private readonly Span<T> _data = data;
+        private readonly int _stride = stride;
+
+        public readonly int Count { get; } = data.Length / stride;
+        public readonly Span<T> this[int index] => _data.Slice(index * _stride, _stride);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator StridedReadOnlySpan<T> (StridedSpan<T> self)
+            => new (self._data, self._stride);
+    }
+
+    internal readonly ref struct StridedReadOnlySpan<T>(ReadOnlySpan<T> data, int stride)
+    {
+        private readonly ReadOnlySpan<T> _data = data;
+        private readonly int _stride = stride;
+
+        public readonly int Count { get; } = data.Length / stride;
+        public readonly ReadOnlySpan<T> this[int index] => _data.Slice(index * _stride, _stride);
+    }
+}

--- a/TACTTool/Program.cs
+++ b/TACTTool/Program.cs
@@ -342,7 +342,7 @@ namespace TACTTool
                 return;
             }
 
-            extractionTargets.Add((fileEKeys.Value.eKeys[0], fileEKeys.Value.decodedFileSize, !string.IsNullOrEmpty(filename) ? filename : cKey));
+            extractionTargets.Add((fileEKeys.Value[0].ToArray(), fileEKeys.Value.DecodedFileSize, !string.IsNullOrEmpty(filename) ? filename : cKey));
         }
 
         private static void HandleFDID(BuildInstance build, string fdid, string? filename)
@@ -366,7 +366,7 @@ namespace TACTTool
                 return;
             }
 
-            extractionTargets.Add((fileEKeys.Value.eKeys[0], fileEKeys.Value.decodedFileSize, !string.IsNullOrEmpty(filename) ? filename : fdid));
+            extractionTargets.Add((fileEKeys.Value[0].ToArray(), fileEKeys.Value.DecodedFileSize, !string.IsNullOrEmpty(filename) ? filename : fdid));
         }
 
         private static void HandleFileName(BuildInstance build, string filename, string? outputFilename)
@@ -403,7 +403,7 @@ namespace TACTTool
             if (!build.Encoding.TryGetEKeys(targetCKey, out var fileEKeys) || fileEKeys == null)
                 throw new Exception("EKey not found in encoding");
 
-            extractionTargets.Add((fileEKeys.Value.eKeys[0], fileEKeys.Value.decodedFileSize, !string.IsNullOrEmpty(outputFilename) ? outputFilename : filename));
+            extractionTargets.Add((fileEKeys.Value[0].ToArray(), fileEKeys.Value.DecodedFileSize, !string.IsNullOrEmpty(outputFilename) ? outputFilename : filename));
         }
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/29aca30e-665d-4efc-98b5-b581e5e86378)

> [!CAUTION]
> This conflicts with the [root](https://github.com/wowdev/TACTSharp/pull/1) PR. Whichever you choose to merge first I'll solve conflicts in whichever's next. Specifically the binary search bits.
>
> Or just merge neither.

The span version appears to have a bit more variance, but it's still averaging at stupid-fast (tm).

```
# linux-arm64
$ /usr/bin/time -v ./TACTTool -p wow -m fdid -i 1439477
        Command being timed: "./TACTTool -p wow -m fdid -i 1439477"
        User time (seconds): 0.16
        System time (seconds): 0.14
        Percent of CPU this job got: 36%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.83
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 312348
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 73488
        Voluntary context switches: 49
        Involuntary context switches: 5
        Swaps: 0
        File system inputs: 0
        File system outputs: 600
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```