### PR TITLE
Minor cleanup of encoding after !2

### DIFF
--- a/TACTSharp/Build.cs
+++ b/TACTSharp/Build.cs
@@ -88,10 +88,11 @@
             if (!BuildConfig.Values.TryGetValue("root", out var rootKey))
                 throw new Exception("No root key found in build config");
 
-            if (!Encoding.TryGetEKeys(Convert.FromHexString(rootKey[0]), out var rootEKeys) || rootEKeys == null)
+            var rootEncodingKeys = Encoding.FindContentKey(Convert.FromHexString(rootKey[0]));
+            if (!rootEncodingKeys)
                 throw new Exception("Root key not found in encoding");
 
-            Root = new RootInstance(CDN.GetDecodedFilePath("wow", "data", Convert.ToHexStringLower(rootEKeys.Value[0]), 0, rootEKeys.Value.DecodedFileSize));
+            Root = new RootInstance(CDN.GetDecodedFilePath("wow", "data", Convert.ToHexStringLower(rootEncodingKeys[0]), 0, rootEncodingKeys.DecodedFileSize));
             timer.Stop();
             Console.WriteLine("Root loaded in " + Math.Ceiling(timer.Elapsed.TotalMilliseconds) + "ms");
 
@@ -99,10 +100,11 @@
             if (!BuildConfig.Values.TryGetValue("install", out var installKey))
                 throw new Exception("No root key found in build config");
 
-            if (!Encoding.TryGetEKeys(Convert.FromHexString(installKey[0]), out var installEKeys) || installEKeys == null)
+            var installEncodingKeys = Encoding.FindContentKey(Convert.FromHexString(installKey[0]));
+            if (!installEncodingKeys)
                 throw new Exception("Install key not found in encoding");
 
-            Install = new InstallInstance(CDN.GetDecodedFilePath("wow", "data", Convert.ToHexStringLower(installEKeys.Value[0]), 0, installEKeys.Value.DecodedFileSize));
+            Install = new InstallInstance(CDN.GetDecodedFilePath("wow", "data", Convert.ToHexStringLower(installEncodingKeys[0]), 0, installEncodingKeys.DecodedFileSize));
             timer.Stop();
             Console.WriteLine("Install loaded in " + Math.Ceiling(timer.Elapsed.TotalMilliseconds) + "ms");
         }
@@ -124,7 +126,7 @@
             if (Encoding == null)
                 throw new Exception("Encoding not loaded");
 
-            var encodingResult = Encoding.GetEKeys(cKey);
+            var encodingResult = Encoding.FindContentKey(cKey);
             if (encodingResult.Length == 0)
                 throw new Exception("File not found in encoding");
 

--- a/TACTSharp/EncodingInstance.cs
+++ b/TACTSharp/EncodingInstance.cs
@@ -80,13 +80,12 @@ namespace TACTSharp
             }
         }
 
-        public bool TryGetEKeys(ReadOnlySpan<byte> cKeyTarget, out EncodingResult? result)
-        {
-            result = GetEKeys(cKeyTarget);
-            return result.HasValue;
-        }
-
-        public unsafe EncodingResult GetEKeys(ReadOnlySpan<byte> cKeyTarget)
+        /// <summary>
+        /// Returns the result of a lookup for a specific content key.
+        /// </summary>
+        /// <param name="cKeyTarget">The content key to look for.</param>
+        /// <returns></returns>
+        public unsafe EncodingResult FindContentKey(ReadOnlySpan<byte> cKeyTarget)
         {
             byte* pageData = null;
             mmapViewHandle.AcquirePointer(ref pageData);
@@ -173,9 +172,11 @@ namespace TACTSharp
 
             public readonly ulong DecodedFileSize = fileSize;
             public readonly ReadOnlySpan<byte> this[int index] => _keys.AsSpan().Slice(_keyLength * index, _keyLength);
-            public readonly int Length => _keys.Length;
+            public readonly int Length => _keyLength;
 
             public static readonly EncodingResult Empty = new(0, [], 0);
+
+            public static implicit operator bool(EncodingResult self) => self._keyLength != 0;
         }
 
         private readonly record struct EncodingSchema(int CKeySize, int EKeySize, Range EncodingSpec, TableSchema CEKey, TableSchema EKeySpec);

--- a/TACTTool/Program.cs
+++ b/TACTTool/Program.cs
@@ -334,15 +334,16 @@ namespace TACTTool
                 Console.WriteLine("Skipping " + cKey + ", invalid formatting for CKey (expected 32 character hex string).");
                 return;
             }
-            var cKeyBytes = Convert.FromHexString(cKey);
 
-            if (!build.Encoding.TryGetEKeys(cKeyBytes, out var fileEKeys) || fileEKeys == null)
+            var cKeyBytes = Convert.FromHexString(cKey);
+            var fileEncodingKeys = build.Encoding.FindContentKey(cKeyBytes);
+            if (!fileEncodingKeys)
             {
                 Console.WriteLine("Skipping " + cKey + ", CKey not found in encoding.");
                 return;
             }
 
-            extractionTargets.Add((fileEKeys.Value[0].ToArray(), fileEKeys.Value.DecodedFileSize, !string.IsNullOrEmpty(filename) ? filename : cKey));
+            extractionTargets.Add((fileEncodingKeys[0].ToArray(), fileEncodingKeys.DecodedFileSize, !string.IsNullOrEmpty(filename) ? filename : cKey));
         }
 
         private static void HandleFDID(BuildInstance build, string fdid, string? filename)
@@ -360,13 +361,14 @@ namespace TACTTool
                 return;
             }
 
-            if (!build.Encoding.TryGetEKeys(fileEntry.Value.md5.AsSpan(), out var fileEKeys) || fileEKeys == null)
+            var fileEncodingKeys = build.Encoding.FindContentKey(fileEntry.Value.md5.AsSpan());
+            if (!fileEncodingKeys)
             {
                 Console.WriteLine("Skipping FDID " + fdid + ", CKey not found in encoding.");
                 return;
             }
 
-            extractionTargets.Add((fileEKeys.Value[0].ToArray(), fileEKeys.Value.DecodedFileSize, !string.IsNullOrEmpty(filename) ? filename : fdid));
+            extractionTargets.Add((fileEncodingKeys[0].ToArray(), fileEncodingKeys.DecodedFileSize, !string.IsNullOrEmpty(filename) ? filename : fdid));
         }
 
         private static void HandleFileName(BuildInstance build, string filename, string? outputFilename)
@@ -417,10 +419,11 @@ namespace TACTTool
                 targetCKey = fileEntries[0].md5;
             }
 
-            if (!build.Encoding.TryGetEKeys(targetCKey, out var fileEKeys) || fileEKeys == null)
+            var fileEncodingKeys = build.Encoding.FindContentKey(targetCKey);
+            if (!fileEncodingKeys)
                 throw new Exception("EKey not found in encoding");
 
-            extractionTargets.Add((fileEKeys.Value[0].ToArray(), fileEKeys.Value.DecodedFileSize, !string.IsNullOrEmpty(outputFilename) ? outputFilename : filename));
+            extractionTargets.Add((fileEncodingKeys[0].ToArray(), fileEncodingKeys.DecodedFileSize, !string.IsNullOrEmpty(outputFilename) ? outputFilename : filename));
         }
     }
 }


### PR DESCRIPTION
* Remove `Encoding.TryGetEKeys`
* Rename `Encoding.GetEKeys(ReadOnlySpan<byte>)` to `FindContentKey(ReadOnlySpan<byte>)`.
* Add implicit boolean conversion operator to `EncodingResult`.